### PR TITLE
reuploading metaSQL files to reflect changes

### DIFF
--- a/doc/README.txt
+++ b/doc/README.txt
@@ -3,7 +3,7 @@ Version 1.0
 
 
 CONTENTS OF THIS FILE
-—————————————————————-
+---------------------
 * Introduction
 * Prerequisites
 * Meta-SQL Statements
@@ -13,18 +13,19 @@ CONTENTS OF THIS FILE
 * License
 
 INTRODUCTION
-————————————
-This extension file contains the JunkSearch Tool.  The tool works by taking user input for an email pattern (regex), date created, and owner username, and queries contacts stored in the cntct table if “Query Contacts” is clicked, and the newly created marked_for_followup table (also included in this extension) if “Query Marked for Review” is clicked.  Once the results list is populated, the various function buttons can be utilized.  Marking a contact for review moves it to the marked_for_followup table. Deleting a contact removes several primary key restrictions by updating restricting columns in other tables and moves the contact from the cntct table and into the temp_junk table (also included in this extension).  By utilizing this tool, all accounts with junk email addresses (for example, ending in “@mailinator.com”) could be eliminated in bulk, freeing up space on the database.
+------------
+This extension file contains the JunkSearch Tool.  The tool works by taking user input for an email pattern (regex), date created, and owner username, and queries contacts stored in the cntct table if "Query Contacts" is clicked, and the newly created marked_for_followup table (also included in this extension) if "Query Marked for Review" is clicked.  Once the results list is populated, the various function buttons can be utilized.  Marking a contact for review moves it to the marked_for_followup table. Deleting a contact removes several primary key restrictions by updating restricting columns in other tables and moves the contact from the cntct table and into the temp_junk table (also included in this extension).  By utilizing this tool, all accounts with junk email addresses (for example, ending in "@mailinator.com") could be eliminated in bulk, freeing up space on the database.
 
-This extension is not perfect, with several issues outlined in the “Contributing” section.  
+This extension is not perfect, with several issues outlined in the "Contributing" section.  
 Perhaps most important is that several changes to the database that this tool makes are irreversible, and CANNOT be undone.  While the temp_junk table (described below) does mitigate some risk, caution should be used when using this tool to avoid deleting data that cannot be recovered.  
 
 PREREQUISITES
-—————————————
+-------------
 
-This tool is fashioned entirely based on the database framework used at xTuple.  In order for this extension to be useable out of the box, the user’s database must mirror xTuple’s exactly in terms of primary keys and table naming.  However, the framework used here could be modified or expanded upon to serve whatever needs the user may have.
+This tool is fashioned entirely based on the database framework used at xTuple.  In order for this extension to be useable out of the box, the user's database must mirror xTuple's exactly in terms of primary keys and table naming.  However, the framework used here could be modified or expanded upon to serve whatever needs the user may have.
+
 META-SQL STATEMENTS
-————————————————————
+-------------------
 
 * deleteAll :  Moves all contacts displayed on interface into the temp_junk table (included in this extension) from the cntct table.  The xTuple database uses primary keys in several tables that restrict removing contacts from the cntct table, so the crmacct, incdt, custinfo, prj, and ophead tables are updated to set the cntct_id column in any corresponding rows to NULL.  While the temp_junk table will store cntct information until the finalize meta-SQL statement is called, and therefore cntct information could be restored by using an SQL query on the database, these changes in other tables are not tracked and therefore CANNOT be restored.
 
@@ -45,22 +46,22 @@ META-SQL STATEMENTS
 * queryMarked :  Queries the marked_for_followup table based on the search criteria provided.
 
 SCRIPTS
-———————
+-------
 
 * junkSearch.js :  Javascript file to create the Junk Search Tool.  Functions are listed below:
 
-	* toggle() :  called when the “Include Ownerless Contacts” checkbox is clicked.  	Changes value of checked between true and false.
-	* getParams() :  Takes user input from the search criteria and stores it in an 		object called “params,” to be later passed to the meta-SQL files.
-	* query() :  Called when the “Query Contacts” button is clicked.  Calls the 		junkSearch meta-SQL statement and populates the list with the results.
-	* reviewAll() :  Called when the “Mark All For Review” button is clicked.  Calls 	markAllForReview meta-SQL statement to copy all contacts shown into the 		marked_for_followup table.
-	* queryMarked() :  Called when the “Query Marked For Review” button is clicked.  	Calls the queryMarked meta-SQL statement and populates the list with the results.
-	* reviewSelected() :  Called when the “Mark Selected For Review” button is 		clicked.  Calls the markOneForReview meta-SQL statement for each selected contact.
-	* deleteAll() : Called when the “Delete All” button is clicked.  If the UI is in 	the cntctView (Query Contacts was most recently clicked), calls deleteAll meta-SQL 	to delete all contacts from cntct that are in the list.  If not in cntctView 		(Query Marked For Review was most recently clicked), calls deleteAllMarked meta-	SQL to delete all contacts in the marked_for_followup table that are on the list.
-	* deleteSelected() :  Called when the “Delete Selected” button is clicked.  Calls 	either deleteSelected or deleteSelectedMarked, depending on which view the UI is 	in.  This loops through the selected contacts to delete them one at a time.
-	* finalize() : Called when the “Finalize” button is clicked.  Calls the finalize 	meta-SQL to delete all contacts from the temp_junk folder.
+	* toggle() :  called when the "Include Ownerless Contacts" checkbox is clicked.  Changes value of checked between true and false.
+	* getParams() :  Takes user input from the search criteria and stores it in an 	object called "params," to be later passed to the meta-SQL files.
+	* query() :  Called when the "Query Contacts" button is clicked.  Calls the junkSearch meta-SQL statement and populates the list with the results.
+	* reviewAll() :  Called when the "Mark All For Review" button is clicked.  Calls markAllForReview meta-SQL statement to copy all contacts shown into the marked_for_followup table.
+	* queryMarked() :  Called when the "Query Marked For Review" button is clicked.  Calls the queryMarked meta-SQL statement and populates the list with the results.
+	* reviewSelected() :  Called when the "Mark Selected For Review" button is clicked.  Calls the markOneForReview meta-SQL statement for each selected contact.
+	* deleteAll() : Called when the "Delete All" button is clicked.  If the UI is in the cntctView (Query Contacts was most recently clicked), calls deleteAll meta-SQL to delete all contacts from cntct that are in the list.  If not in cntctView (Query Marked For Review was most recently clicked), calls deleteAllMarked meta-SQL to delete all contacts in the marked_for_followup table that are on the list.
+	* deleteSelected() :  Called when the "Delete Selected" button is clicked.  Calls either deleteSelected or deleteSelectedMarked, depending on which view the UI is in.  This loops through the selected contacts to delete them one at a time.
+	* finalize() : Called when the "Finalize" button is clicked.  Calls the finalize meta-SQL to delete all contacts from the temp_junk folder.
 
 TABLES
-——————
+------
 
 * marked_for_followup :  This table stores all information stored by the cntct table, and is used to store copies of contacts in the cntct table that have been marked for review before being deleted.
 
@@ -68,16 +69,16 @@ TABLES
 
 
 CONTRIBUTING
-————————————
+------------
 
-One large hinderance that this tool has is the irreversibility of some of its functions.  A single button click could drastically alter stored data.  An undo function was attempted, but due to restrictions caused by primary keys in other tables, this feature was ultimately stricken from Version 1.0 in favor of the “finalize” function and temp_junk table.  In future updates this fix would increase usability and decrease risk of accidentally removing a file.
+One large hinderance that this tool has is the irreversibility of some of its functions.  A single button click could drastically alter stored data.  An undo function was attempted, but due to restrictions caused by primary keys in other tables, this feature was ultimately stricken from Version 1.0 in favor of the "finalize" function and temp_junk table.  In future updates this fix would increase usability and decrease risk of accidentally removing a file.
 
 A more simple fix that would also help combat the problem described above would be to add a pop-up window that prompts the user to confirm that they do want to remove the selected contacts from their database.
 
 In some places the code for this is rather messy and could in all likelihood be optimized to increase speed as well as make contribution to the code easier.
 
 LICENSE
-———————
+-------
 
 Copyright (c) 2018 Connor Yager
 

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -3,7 +3,7 @@ Version 1.0
 
 
 CONTENTS OF THIS FILE
----------------------
+—————————————————————-
 * Introduction
 * Prerequisites
 * Meta-SQL Statements
@@ -13,19 +13,18 @@ CONTENTS OF THIS FILE
 * License
 
 INTRODUCTION
-------------
-This extension file contains the JunkSearch Tool.  The tool works by taking user input for an email pattern (regex), date created, and owner username, and queries contacts stored in the cntct table if "Query Contacts" is clicked, and the newly created marked_for_followup table (also included in this extension) if "Query Marked for Review" is clicked.  Once the results list is populated, the various function buttons can be utilized.  Marking a contact for review moves it to the marked_for_followup table. Deleting a contact removes several primary key restrictions by updating restricting columns in other tables and moves the contact from the cntct table and into the temp_junk table (also included in this extension).  By utilizing this tool, all accounts with junk email addresses (for example, ending in "@mailinator.com") could be eliminated in bulk, freeing up space on the database.
+————————————
+This extension file contains the JunkSearch Tool.  The tool works by taking user input for an email pattern (regex), date created, and owner username, and queries contacts stored in the cntct table if “Query Contacts” is clicked, and the newly created marked_for_followup table (also included in this extension) if “Query Marked for Review” is clicked.  Once the results list is populated, the various function buttons can be utilized.  Marking a contact for review moves it to the marked_for_followup table. Deleting a contact removes several primary key restrictions by updating restricting columns in other tables and moves the contact from the cntct table and into the temp_junk table (also included in this extension).  By utilizing this tool, all accounts with junk email addresses (for example, ending in “@mailinator.com”) could be eliminated in bulk, freeing up space on the database.
 
-This extension is not perfect, with several issues outlined in the "Contributing" section.  
+This extension is not perfect, with several issues outlined in the “Contributing” section.  
 Perhaps most important is that several changes to the database that this tool makes are irreversible, and CANNOT be undone.  While the temp_junk table (described below) does mitigate some risk, caution should be used when using this tool to avoid deleting data that cannot be recovered.  
 
 PREREQUISITES
--------------
+—————————————
 
-This tool is fashioned entirely based on the database framework used at xTuple.  In order for this extension to be useable out of the box, the user's database must mirror xTuple's exactly in terms of primary keys and table naming.  However, the framework used here could be modified or expanded upon to serve whatever needs the user may have.
-
+This tool is fashioned entirely based on the database framework used at xTuple.  In order for this extension to be useable out of the box, the user’s database must mirror xTuple’s exactly in terms of primary keys and table naming.  However, the framework used here could be modified or expanded upon to serve whatever needs the user may have.
 META-SQL STATEMENTS
--------------------
+————————————————————
 
 * deleteAll :  Moves all contacts displayed on interface into the temp_junk table (included in this extension) from the cntct table.  The xTuple database uses primary keys in several tables that restrict removing contacts from the cntct table, so the crmacct, incdt, custinfo, prj, and ophead tables are updated to set the cntct_id column in any corresponding rows to NULL.  While the temp_junk table will store cntct information until the finalize meta-SQL statement is called, and therefore cntct information could be restored by using an SQL query on the database, these changes in other tables are not tracked and therefore CANNOT be restored.
 
@@ -46,22 +45,22 @@ META-SQL STATEMENTS
 * queryMarked :  Queries the marked_for_followup table based on the search criteria provided.
 
 SCRIPTS
--------
+———————
 
 * junkSearch.js :  Javascript file to create the Junk Search Tool.  Functions are listed below:
 
-	* toggle() :  called when the "Include Ownerless Contacts" checkbox is clicked.  Changes value of checked between true and false.
-	* getParams() :  Takes user input from the search criteria and stores it in an 	object called "params," to be later passed to the meta-SQL files.
-	* query() :  Called when the "Query Contacts" button is clicked.  Calls the junkSearch meta-SQL statement and populates the list with the results.
-	* reviewAll() :  Called when the "Mark All For Review" button is clicked.  Calls markAllForReview meta-SQL statement to copy all contacts shown into the marked_for_followup table.
-	* queryMarked() :  Called when the "Query Marked For Review" button is clicked.  Calls the queryMarked meta-SQL statement and populates the list with the results.
-	* reviewSelected() :  Called when the "Mark Selected For Review" button is clicked.  Calls the markOneForReview meta-SQL statement for each selected contact.
-	* deleteAll() : Called when the "Delete All" button is clicked.  If the UI is in the cntctView (Query Contacts was most recently clicked), calls deleteAll meta-SQL to delete all contacts from cntct that are in the list.  If not in cntctView (Query Marked For Review was most recently clicked), calls deleteAllMarked meta-SQL to delete all contacts in the marked_for_followup table that are on the list.
-	* deleteSelected() :  Called when the "Delete Selected" button is clicked.  Calls either deleteSelected or deleteSelectedMarked, depending on which view the UI is in.  This loops through the selected contacts to delete them one at a time.
-	* finalize() : Called when the "Finalize" button is clicked.  Calls the finalize meta-SQL to delete all contacts from the temp_junk folder.
+	* toggle() :  called when the “Include Ownerless Contacts” checkbox is clicked.  	Changes value of checked between true and false.
+	* getParams() :  Takes user input from the search criteria and stores it in an 		object called “params,” to be later passed to the meta-SQL files.
+	* query() :  Called when the “Query Contacts” button is clicked.  Calls the 		junkSearch meta-SQL statement and populates the list with the results.
+	* reviewAll() :  Called when the “Mark All For Review” button is clicked.  Calls 	markAllForReview meta-SQL statement to copy all contacts shown into the 		marked_for_followup table.
+	* queryMarked() :  Called when the “Query Marked For Review” button is clicked.  	Calls the queryMarked meta-SQL statement and populates the list with the results.
+	* reviewSelected() :  Called when the “Mark Selected For Review” button is 		clicked.  Calls the markOneForReview meta-SQL statement for each selected contact.
+	* deleteAll() : Called when the “Delete All” button is clicked.  If the UI is in 	the cntctView (Query Contacts was most recently clicked), calls deleteAll meta-SQL 	to delete all contacts from cntct that are in the list.  If not in cntctView 		(Query Marked For Review was most recently clicked), calls deleteAllMarked meta-	SQL to delete all contacts in the marked_for_followup table that are on the list.
+	* deleteSelected() :  Called when the “Delete Selected” button is clicked.  Calls 	either deleteSelected or deleteSelectedMarked, depending on which view the UI is 	in.  This loops through the selected contacts to delete them one at a time.
+	* finalize() : Called when the “Finalize” button is clicked.  Calls the finalize 	meta-SQL to delete all contacts from the temp_junk folder.
 
 TABLES
-------
+——————
 
 * marked_for_followup :  This table stores all information stored by the cntct table, and is used to store copies of contacts in the cntct table that have been marked for review before being deleted.
 
@@ -69,16 +68,16 @@ TABLES
 
 
 CONTRIBUTING
-------------
+————————————
 
-One large hinderance that this tool has is the irreversibility of some of its functions.  A single button click could drastically alter stored data.  An undo function was attempted, but due to restrictions caused by primary keys in other tables, this feature was ultimately stricken from Version 1.0 in favor of the "finalize" function and temp_junk table.  In future updates this fix would increase usability and decrease risk of accidentally removing a file.
+One large hinderance that this tool has is the irreversibility of some of its functions.  A single button click could drastically alter stored data.  An undo function was attempted, but due to restrictions caused by primary keys in other tables, this feature was ultimately stricken from Version 1.0 in favor of the “finalize” function and temp_junk table.  In future updates this fix would increase usability and decrease risk of accidentally removing a file.
 
 A more simple fix that would also help combat the problem described above would be to add a pop-up window that prompts the user to confirm that they do want to remove the selected contacts from their database.
 
 In some places the code for this is rather messy and could in all likelihood be optimized to increase speed as well as make contribution to the code easier.
 
 LICENSE
--------
+———————
 
 Copyright (c) 2018 Connor Yager
 

--- a/resources/client/metasql/cleanup-deleteAll.mql
+++ b/resources/client/metasql/cleanup-deleteAll.mql
@@ -35,11 +35,14 @@ FROM cntct
     <? if exists("pattern") ?>
          AND cntct_email ~* <? value("pattern") ?>
     <? endif ?>
-     <? if exists("owner") ?>
+    <? if exists("owner") ?>
          AND UPPER(cntct_owner_username) = UPPER(<? value("owner") ?>)
-     <? endif ?>
-     <? if exists("ownerless") ?>
-        OR cntct_owner_username = ''
+    <? endif ?>
+    <? if exists("ownerless") ?>
+        OR (cntct_owner_username = ''
+	<? if exists("pattern") ?>
+	  AND cntct_email ~* <? value("pattern") ?>
+	<? endif ?>)
     <? endif ?>;
 
 --Sets cntct_id fields in crmacct to NULL if crmacct_id is found in temp_junk table, which should bypass key constraints

--- a/resources/client/metasql/cleanup-deleteAllMarked.mql
+++ b/resources/client/metasql/cleanup-deleteAllMarked.mql
@@ -10,5 +10,8 @@ DELETE FROM marked_for_followup
          AND UPPER(cntct_owner_username) = UPPER(<? value("owner") ?>)
     <? endif ?>
     <? if exists("ownerless") ?>
-        OR cntct_owner_username = ''
+        OR (cntct_owner_username = ''
+	<? if exists("pattern") ?>
+	  AND cntct_email ~* <? value("pattern") ?>
+	<? endif ?>)
     <? endif ?>;

--- a/resources/client/metasql/cleanup-junkSearch.mql
+++ b/resources/client/metasql/cleanup-junkSearch.mql
@@ -16,12 +16,17 @@ cntct_created
          AND cntct_email ~* <? value("pattern") ?>
     <? endif ?>
     -- Filters based on the pattern if it is provided
-     <? if exists("owner") ?>
-         AND UPPER(cntct_owner_username) = UPPER(<? value("owner") ?>)
+   <? if exists("owner") ?>
+        AND UPPER(cntct_owner_username) = UPPER(<? value("owner") ?>)
     <? endif ?>
     <? if exists("ownerless") ?>
-        OR cntct_owner_username = ''
+        OR (cntct_owner_username = ''
+	<? if exists("pattern") ?>
+	  AND cntct_email ~* <? value("pattern") ?>
+	<? endif ?>)
     <? endif ?>
+
+    
     
      
      -- Filters based on the owner if it is provided

--- a/resources/client/metasql/cleanup-markAllForReview.mql
+++ b/resources/client/metasql/cleanup-markAllForReview.mql
@@ -37,7 +37,10 @@ cntct_lastupdated
          AND UPPER(cntct_owner_username) = UPPER(<? value("owner") ?>)
     <? endif ?>
     <? if exists("ownerless") ?>
-        OR cntct_owner_username = ''
+        OR (cntct_owner_username = ''
+	<? if exists("pattern") ?>
+	  AND cntct_email ~* <? value("pattern") ?>
+	<? endif ?>)
     <? endif ?>;
 
 

--- a/resources/client/metasql/cleanup-markOneForReview.mql
+++ b/resources/client/metasql/cleanup-markOneForReview.mql
@@ -28,4 +28,4 @@ obj_uuid,
 cntct_created,
 cntct_lastupdated
   FROM cntct
- WHERE cntct_id = <? value ("id") ?>
+ WHERE cntct_id = <? value ("id") ?>;

--- a/resources/client/metasql/cleanup-queryMarked.mql
+++ b/resources/client/metasql/cleanup-queryMarked.mql
@@ -21,6 +21,9 @@ cntct_created
     <? endif ?>
      -- Filters based on the owner if it is provided
     <? if exists("ownerless") ?>
-        OR cntct_owner_username = ''
+        OR (cntct_owner_username = ''
+	<? if exists("pattern") ?>
+	  AND cntct_email ~* <? value("pattern") ?>
+	<? endif ?>)
     <? endif ?>
 ORDER BY cntct_first_name, cntct_last_name; 


### PR DESCRIPTION
Made a slight change to the basic query section of the metaSQL where checking the ownerless box caused the query to return ALL ownerless contacts instead of only the ones that match the rest of the search criteria